### PR TITLE
Fix qparams matmulunary

### DIFF
--- a/core/src/ops/matmul/mir.rs
+++ b/core/src/ops/matmul/mir.rs
@@ -302,7 +302,7 @@ impl TypedOp for MatMul {
         let patch = TypedModelPatch::replace_single_op(
             model,
             node,
-            &node.inputs[var_ix..][..1],
+            &node.inputs[var_ix..],
             MatMulUnary::new(konst, t_konst, t_var, self.c_trans ^ flip, q_params),
         )?
         .with_context("to unary");

--- a/core/src/ops/matmul/mir.rs
+++ b/core/src/ops/matmul/mir.rs
@@ -298,11 +298,12 @@ impl TypedOp for MatMul {
         let t_konst = [self.a_trans, self.b_trans][konst_ix] ^ flip;
         let t_var = [self.b_trans, self.a_trans][konst_ix] ^ flip;
         let konst = model.outlet_fact(node.inputs[konst_ix])?.konst.clone().unwrap();
+        let q_params = self.q_params.clone().map(|qp| qp.with_inputs_kind_offset(-1));
         let patch = TypedModelPatch::replace_single_op(
             model,
             node,
             &node.inputs[var_ix..][..1],
-            MatMulUnary::new(konst, t_konst, t_var, self.c_trans ^ flip, self.q_params.clone()),
+            MatMulUnary::new(konst, t_konst, t_var, self.c_trans ^ flip, q_params),
         )?
         .with_context("to unary");
         return Ok(Some(patch));

--- a/core/src/ops/quant.rs
+++ b/core/src/ops/quant.rs
@@ -51,6 +51,20 @@ pub enum QParamsInputKind {
     ScaleABC(usize, usize, usize),
 }
 
+impl QParamsInputKind {
+    fn offset(&self, count: isize) -> Self {
+        let offset = |ix: &usize| ((*ix as isize) + count) as usize;
+        match self {
+            QParamsInputKind::ZeroPointA(ix) => QParamsInputKind::ZeroPointA(offset(ix)),
+            QParamsInputKind::ZeroPointB(ix) => QParamsInputKind::ZeroPointB(offset(ix)),
+            QParamsInputKind::ZeroPointC(ix) => QParamsInputKind::ZeroPointC(offset(ix)),
+            QParamsInputKind::ScaleABC(a_ix, b_ix, c_ix) => {
+                QParamsInputKind::ScaleABC(offset(a_ix), offset(b_ix), offset(c_ix))
+            }
+        }
+    }
+}
+
 impl QParams {
     pub fn new(dt: DatumType) -> QParams {
         QParams {
@@ -101,6 +115,14 @@ impl QParams {
 
     pub fn set_inputs_kind(&mut self, inputs_kind: TVec<QParamsInputKind>) {
         self.inputs_kind = Some(inputs_kind);
+    }
+
+    pub fn with_inputs_kind_offset(self, count: isize) -> QParams {
+        let inputs_kind = self.inputs_kind.map(|inputs_kind| {
+            inputs_kind.iter().map(|input_kind| input_kind.offset(count)).collect()
+        });
+
+        QParams { inputs_kind, ..self }
     }
 }
 


### PR DESCRIPTION
Shift the offset of elements in `inputs_kind` when creating a `MatMulUnary` since we are removing one input.
Pass all other inputs to `MatMulUnary`.