### PR TITLE
Workaround to fix jump dependes on uninit var from valgrind

### DIFF
--- a/hir/src/ops/array/reshape.rs
+++ b/hir/src/ops/array/reshape.rs
@@ -53,6 +53,7 @@ fn compute_shape(input: &[TDim], shape_spec: &[TDim]) -> TractResult<TVec<TDim>>
     let mut shape: TVec<TDim> = shape_spec.into();
 
     // deal with zeros, stop if we see a -1
+    #[inline(never)]
     fn deal_with_zero<'a>(
         mut input_dims: std::iter::Peekable<impl Iterator<Item = &'a TDim>>,
         shape: &mut [TDim],


### PR DESCRIPTION
Avoiding that function to inline remove the conditional jump from an unitialized variable.
This happen with older version of tract. Seems to be present from rustc 1.46.0 while with 1.45.0 this is not needed.